### PR TITLE
Add support for latest mc & fix #61

### DIFF
--- a/Plugin/build.gradle.kts
+++ b/Plugin/build.gradle.kts
@@ -138,7 +138,7 @@ dependencies {
 
     //Paper
     compileOnly("io.papermc.paper:paper-api:1.21.11-R0.1-SNAPSHOT")
-    implementation("com.github.retrooper:packetevents-spigot:2.11.0")
+    implementation("com.github.retrooper:packetevents-spigot:2.12.1")
     compileOnly("org.apache.logging.log4j:log4j-core:2.25.1")
 
     //Libby

--- a/Plugin/src/main/java/xyz/kyngs/librelogin/paper/PaperListeners.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/paper/PaperListeners.java
@@ -207,8 +207,6 @@ public class PaperListeners extends AuthenticListeners<PaperLibreLogin, Player, 
                     && !isLimbo.apply(eventSpawnLocation.getWorld())
                     && isLimbo.apply(world.value())) {
                 spawnLocationCache.put(puuid, eventSpawnLocation);
-            } else {
-                return;
             }
 
             var loc = world.value().getSpawnLocation();

--- a/Plugin/src/main/java/xyz/kyngs/librelogin/velocity/VelocityBootstrap.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/velocity/VelocityBootstrap.java
@@ -32,7 +32,7 @@ import xyz.kyngs.librelogin.api.provider.LibreLoginProvider;
         name = "LibreLogin",
         version = "@version@",
         // TODO: Update authors
-        authors = "sapphirecode",
+        authors = {"vuxeim", "sapphirecode"},
         dependencies = {
             @Dependency(id = "floodgate", optional = true),
             @Dependency(id = "luckperms", optional = true),

--- a/Plugin/src/main/resources/paper-plugin.yml
+++ b/Plugin/src/main/resources/paper-plugin.yml
@@ -1,5 +1,5 @@
 name: "LibreLogin"
-authors: [ "sapphirecode", "Navio1430", "kyngs" ]
+authors: [ "vuxeim", "sapphirecode", "Navio1430", "kyngs" ]
 version: '${version}'
 main: "xyz.kyngs.librelogin.paper.PaperBootstrap"
 api-version: "1.19"

--- a/Plugin/src/main/resources/plugin.yml
+++ b/Plugin/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: "LibreLogin"
-authors: [ "sapphirecode", "Navio1430", "kyngs" ]
+authors: [ "vuxeim", "sapphirecode", "Navio1430", "kyngs" ]
 version: '${version}'
 main: "xyz.kyngs.librelogin.paper.PaperBootstrap"
 api-version: 1.13

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 defaultTasks("updateLicenses", "shadowJar")
 
-version = "0.25.8"
+version = "0.25.9"
 
 subprojects {
     version = rootProject.version

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- This PR brins support for latest mc version 26.1.2
- For Paper servers: This PR fixes #61
- Bumps plugin version to 0.25.9
- Also I've added myself as a contributor