### PR TITLE
fix(paper): prevent players from being incorrectly teleported to world spawn on login

### DIFF
--- a/Plugin/src/main/java/xyz/kyngs/librelogin/paper/PaperListeners.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/paper/PaperListeners.java
@@ -92,9 +92,9 @@ public class PaperListeners extends AuthenticListeners<PaperLibreLogin, Player, 
 
         readOnlyUserCache = Caffeine.newBuilder().expireAfterWrite(2, TimeUnit.MINUTES).build();
 
-        spawnLocationCache = Caffeine.newBuilder().expireAfterWrite(2, TimeUnit.MINUTES).build();
+        spawnLocationCache = Caffeine.newBuilder().expireAfterWrite(1, TimeUnit.HOURS).build();
 
-        joinedWhileDead = Caffeine.newBuilder().expireAfterWrite(2, TimeUnit.MINUTES).build();
+        joinedWhileDead = Caffeine.newBuilder().expireAfterWrite(1, TimeUnit.HOURS).build();
     }
 
     public Cache<UUID, Location> getSpawnLocationCache() {

--- a/Plugin/src/main/java/xyz/kyngs/librelogin/paper/PaperListeners.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/paper/PaperListeners.java
@@ -209,7 +209,13 @@ public class PaperListeners extends AuthenticListeners<PaperLibreLogin, Player, 
                 spawnLocationCache.put(puuid, eventSpawnLocation);
             }
 
-            var loc = world.value().getSpawnLocation();
+            Location loc;
+            if (world.key() && eventSpawnLocation.getWorld().equals(world.value())) {
+                loc = eventSpawnLocation;
+            } else {
+                loc = world.value().getSpawnLocation();
+            }
+
             joinedWhileDead.put(puuid, loc);
             event.setSpawnLocation(loc);
         }


### PR DESCRIPTION
## Description
This PR fixes a critical and highly disruptive bug on Paper where players are frequently teleported to the world's default spawn `(0, y, 0)` upon joining, instead of spawning at their actual logout coordinates.

## Motivation and Context
Many server owners and players experienced an issue where their survival coordinates were permanently lost upon logging in. After investigating the Paper module, I identified two root causes for this behavior, which this PR addresses:

1. **Session/Auto-login Bug**: In `chooseWorld` (`PaperListeners.java`), the event spawn location was being unconditionally overwritten by `world.value().getSpawnLocation()`. When a player has an active session, they bypass the `/login` phase and its subsequent teleportation logic. Consequently, their logout coordinates were forcibly overwritten by the world's default spawn upon joining. 
   - **Fix**: The code now checks if the player is authorized (`world.key()`) and staying in the same world. If true, their `eventSpawnLocation` is preserved.

2. **Cache Expiration Bug**: The `spawnLocationCache` was set to expire after exactly 2 minutes. If an unauthorized player took slightly longer than 2 minutes to type `/login <password>`, the cache would return `null`, causing the fallback logic to teleport them to the world spawn instead of their original location.
   - **Fix**: Increased the Caffeine cache expiration from 2 minutes to 1 hour to allow ample time for authentication without risking coordinate loss.

## How Has This Been Tested?
- [x] Logged into the server as a new player without a session (verified Limbo teleportation and `/login` correctly restores coordinates after 5+ minutes).
- [x] Logged into the server with an active session/auto-login (verified the player spawns exactly at their logout coordinates instead of the world spawn).
- [x] Tested joining while dead.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
